### PR TITLE
Fix document upload

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -167,8 +167,9 @@ def get_document_mappen(db: Session, project_id: int):
 def upload_document(db: Session, document: schemas.DocumentCreate):
     db_doc = Document(
         bestandsnaam=document.bestandsnaam,
+        pad=document.pad,
         map_id=document.map_id,
-        project_id=document.project_id
+        project_id=document.project_id,
     )
     db.add(db_doc)
     db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -147,12 +147,13 @@ def upload_document(
 
     document_create = schemas.DocumentCreate(
         bestandsnaam=filename,
-        bestandslocatie=filepath,
-        map_id=map_id
+        pad=filepath,
+        project_id=project_id,
+        map_id=map_id,
     )
     db = SessionLocal()
     try:
-        crud.add_document_to_project(db, project_id=project_id, document=document_create)
+        crud.upload_document(db, document=document_create)
     finally:
         db.close()
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -107,6 +107,17 @@ class AfspraakOut(AfspraakBase):
 # DOCUMENTEN
 # =====================
 
+class DocumentBase(BaseModel):
+    bestandsnaam: str
+    pad: str
+    project_id: int
+    map_id: Optional[int] = None
+
+
+class DocumentCreate(DocumentBase):
+    pass
+
+
 class DocumentOut(BaseModel):
     id: int
     bestandsnaam: str


### PR DESCRIPTION
## Summary
- add DocumentCreate schema for uploading documents
- store file path when uploading to DB
- use new schema in upload route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68482a2baea8832fa8786d47193f041c