### PR TITLE
Implement document upload CRUD function

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -164,12 +164,16 @@ def create_document_map(db: Session, project_id: int, map_data: schemas.Document
 def get_document_mappen(db: Session, project_id: int):
     return db.query(DocumentMap).filter(DocumentMap.project_id == project_id).all()
 
-def upload_document(db: Session, document: schemas.DocumentCreate):
+def add_document_to_project(
+    db: Session, project_id: int, document: schemas.DocumentCreate
+) -> Document:
+    """Koppel een document aan een project en sla het op."""
+
     db_doc = Document(
         bestandsnaam=document.bestandsnaam,
         pad=document.pad,
+        project_id=project_id,
         map_id=document.map_id,
-        project_id=document.project_id,
     )
     db.add(db_doc)
     db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -153,7 +153,7 @@ def upload_document(
     )
     db = SessionLocal()
     try:
-        crud.upload_document(db, document=document_create)
+        crud.add_document_to_project(db, project_id=project_id, document=document_create)
     finally:
         db.close()
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -107,15 +107,13 @@ class AfspraakOut(AfspraakBase):
 # DOCUMENTEN
 # =====================
 
-class DocumentBase(BaseModel):
+class DocumentCreate(BaseModel):
+    """Schema for creating a new document."""
+
     bestandsnaam: str
     pad: str
     project_id: int
     map_id: Optional[int] = None
-
-
-class DocumentCreate(DocumentBase):
-    pass
 
 
 class DocumentOut(BaseModel):


### PR DESCRIPTION
## Summary
- define `DocumentCreate` schema directly
- add new `add_document_to_project` CRUD helper
- use the new CRUD helper in the upload endpoint

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684830e06880832fb5f9ca74caa2fd65