### PR TITLE
Add DocumentCreate schema

### DIFF
--- a/erp_app/app/schemas.py
+++ b/erp_app/app/schemas.py
@@ -116,6 +116,15 @@ class DocumentOut(BaseModel):
         from_attributes = True
 
 
+class DocumentCreate(BaseModel):
+    """Schema voor het aanmaken van een Document."""
+
+    bestandsnaam: str
+    project_id: int
+    map_id: Optional[int] = None
+    pad: Optional[str] = None
+
+
 class DocumentMapCreate(BaseModel):
     naam: str
 


### PR DESCRIPTION
## Summary
- add missing `DocumentCreate` model so CRUD functions can use it

## Testing
- `npm test --silent -- --watchAll=false`
- `python -m erp_app.app.main` (fails initially due to missing deps)
- `pip install fastapi sqlalchemy uvicorn pydantic email-validator python-multipart --quiet`
- `python -m erp_app.app.main`

------
https://chatgpt.com/codex/tasks/task_e_6848818a6400832f9a32b713c6959400