### PR TITLE
Add DocumentCreate schema

### DIFF
--- a/erp_app/app/crud.py
+++ b/erp_app/app/crud.py
@@ -167,6 +167,7 @@ def get_document_mappen(db: Session, project_id: int):
 def upload_document(db: Session, document: schemas.DocumentCreate):
     db_doc = Document(
         bestandsnaam=document.bestandsnaam,
+        pad=document.pad,
         map_id=document.map_id,
         project_id=document.project_id
     )

--- a/erp_app/app/main.py
+++ b/erp_app/app/main.py
@@ -147,12 +147,13 @@ def upload_document(
 
     document_create = schemas.DocumentCreate(
         bestandsnaam=filename,
-        bestandslocatie=filepath,
-        map_id=map_id
+        pad=filepath,
+        map_id=map_id,
+        project_id=project_id
     )
     db = SessionLocal()
     try:
-        crud.add_document_to_project(db, project_id=project_id, document=document_create)
+        crud.upload_document(db, document_create)
     finally:
         db.close()
 

--- a/erp_app/app/schemas.py
+++ b/erp_app/app/schemas.py
@@ -116,6 +116,15 @@ class DocumentOut(BaseModel):
         from_attributes = True
 
 
+class DocumentCreate(BaseModel):
+    """Schema voor het aanmaken van een Document."""
+
+    bestandsnaam: str
+    project_id: int
+    map_id: Optional[int] = None
+    pad: Optional[str] = None
+
+
 class DocumentMapCreate(BaseModel):
     naam: str
 


### PR DESCRIPTION
## Summary
- add missing `DocumentCreate` model so CRUD functions can use it
- connect backend upload route with new schema

## Testing
- `npm test --silent -- --watchAll=false`
- `uvicorn erp_app.app.main:app --port 8000 --host 0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_6848818a6400832f9a32b713c6959400